### PR TITLE
ci: add shellcheck workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,20 @@
+name: ShellCheck
+on:
+  push:
+  pull_request:
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ShellCheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run ShellCheck
+        run: |
+          files=$(git ls-files '*.sh')
+          if [ -n "$files" ]; then
+            shellcheck $files
+          else
+            echo "No shell scripts to check."
+          fi


### PR DESCRIPTION
## Summary
- add shellcheck workflow to lint shell scripts

## Testing
- `shellcheck entrypoint.sh` *(fails: SC2034 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689ba5711eb08332b10c3eb645661a64