### PR TITLE
Remove unused variables to satisfy ShellCheck

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,18 +5,13 @@ set -o pipefail
 # --- Visual & Color Definitions ---
 NC='\033[0m' # No Color
 BOLD='\033[1m'
-UNDERLINE='\033[4m'
 # --- Standard Colors ---
-RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
-BLUE='\033[0;34m'
-MAGENTA='\033[0;35m'
 CYAN='\033[0;36m'
 # --- Bright Colors ---
 LIGHT_RED='\033[1;31m'
 LIGHT_GREEN='\033[1;32m'
-LIGHT_YELLOW='\033[1;33m'
 LIGHT_BLUE='\033[1;34m'
 LIGHT_MAGENTA='\033[1;35m'
 LIGHT_CYAN='\033[1;36m'
@@ -58,8 +53,6 @@ echo -e "${LIGHT_BLUE}${BOLD}${B_LEFT}$(printf '%*s' 60 '' | tr ' ' "${H_LINE}")
 
 # --- Environment and File Definitions ---
 BASE_DIR="/data/whatsapp-server"
-ENV_FILE="${BASE_DIR}/.env"
-PID_FILE="${BASE_DIR}/service.pid"
 SERVICE_LOG_FILE="${BASE_DIR}/service.log"
 CRON_LOG_FILE="${BASE_DIR}/cron.log"
 EXECUTABLE_NAME="titansys-whatsapp-linux"


### PR DESCRIPTION
## Summary
- remove unused color variables and file paths from entrypoint

## Testing
- `shellcheck entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_689ba7e4a068833280ca99635c895ba2