### PR TITLE
Ignore unused variable warnings in ShellCheck workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           files=$(git ls-files '*.sh')
           if [ -n "$files" ]; then
-            shellcheck $files
+            shellcheck -e SC2034 $files
           else
             echo "No shell scripts to check."
           fi


### PR DESCRIPTION
## Summary
- ignore SC2034 unused variable warnings in shellcheck workflow

## Testing
- `shellcheck /tmp/test.sh`
- `shellcheck -e SC2034 /tmp/test.sh`
- `files=$(git ls-files '*.sh'); if [ -n "$files" ]; then shellcheck -e SC2034 $files; else echo 'No shell scripts'; fi`


------
https://chatgpt.com/codex/tasks/task_e_689babb788b08332919390ca7815da74